### PR TITLE
Fix board padding issues (JPA-34)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -46,7 +46,7 @@
   }
   
   .game-board {
-    @apply grid grid-cols-3 gap-2 p-4 bg-white rounded-xl shadow-xl border-2 border-gray-200;
+    @apply grid grid-cols-3 gap-1 p-2 bg-white rounded-xl shadow-xl border-2 border-gray-200;
   }
   
   .game-cell {
@@ -100,4 +100,4 @@
     from { box-shadow: 0 0 20px -10px theme('colors.primary.500'); }
     to { box-shadow: 0 0 20px -5px theme('colors.primary.500'); }
   }
-} 
+}

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -60,7 +60,7 @@ const GamePage: React.FC = () => {
   };
 
   const getCellClassName = (index: number) => {
-    let className = "h-20 w-20 bg-gray-700 rounded-lg text-3xl font-bold transition-all duration-200 hover:bg-gray-600 flex items-center justify-center cursor-pointer";
+    let className = "h-16 w-16 bg-gray-700 rounded-lg text-3xl font-bold transition-all duration-200 hover:bg-gray-600 flex items-center justify-center cursor-pointer";
     
     if (board[index]) {
       className += " cursor-not-allowed";
@@ -112,7 +112,7 @@ const GamePage: React.FC = () => {
 
           {/* Game Board */}
           <motion.div
-            className="grid grid-cols-3 gap-2 bg-gray-800 p-4 rounded-2xl shadow-2xl mx-auto max-w-md mb-8"
+            className="grid grid-cols-3 gap-1 bg-gray-800 p-2 rounded-2xl shadow-2xl mx-auto max-w-sm mb-8"
             initial={{ scale: 0.8 }}
             animate={{ scale: 1 }}
             transition={{ duration: 0.5 }}
@@ -176,4 +176,4 @@ const GamePage: React.FC = () => {
   );
 };
 
-export default GamePage; 
+export default GamePage;


### PR DESCRIPTION
## Overview
Fixes padding and spacing issues with the tic-tac-toe game board to improve visual layout and proportions.

## Changes Made
- **Board Container**: Reduced padding from `p-4` to `p-2` for less excessive spacing
- **Cell Spacing**: Decreased gap between cells from `gap-2` to `gap-1` for tighter grid
- **Cell Size**: Reduced individual cell dimensions from `h-20 w-20` to `h-16 w-16` for better proportions  
- **Board Width**: Changed maximum width from `max-w-md` to `max-w-sm` for more compact display
- **CSS Consistency**: Updated `.game-board` class in index.css to match new spacing values

## Technical Details
Updated files:
- `src/pages/GamePage.tsx`: Modified board container classes and cell sizing function
- `src/index.css`: Updated game-board CSS class for consistency

## Testing
- Visual inspection of board layout shows improved proportions
- All game functionality remains intact
- Responsive design maintained across screen sizes

## Fixes
Resolves JPA-34: "fix the padding on the board"

The changes eliminate excessive whitespace around and between board elements, creating a more visually appealing and properly proportioned tic-tac-toe board interface.